### PR TITLE
Only use message_stats if available

### DIFF
--- a/junebug/api.py
+++ b/junebug/api.py
@@ -705,12 +705,10 @@ class JunebugApi(object):
                         if("message_stats" in queue):
                             details['rate'] = \
                                 queue['message_stats']['ack_details']['rate']
-                        else:
-                            details['rate'] = queue['messages_details']['rate']
 
-                        if (details['messages'] > 0 and details['rate'] == 0):
-                            stuck = True
-                            details['stuck'] = True
+                            if (details['messages'] > 0 and details['rate'] == 0):
+                                stuck = True
+                                details['stuck'] = True
 
                         queues.append(details)
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -706,7 +706,8 @@ class JunebugApi(object):
                             details['rate'] = \
                                 queue['message_stats']['ack_details']['rate']
 
-                            if (details['messages'] > 0 and details['rate'] == 0):
+                            if (details['messages'] > 0
+                                    and details['rate'] == 0):
                                 stuck = True
                                 details['stuck'] = True
 

--- a/junebug/api.py
+++ b/junebug/api.py
@@ -699,9 +699,15 @@ class JunebugApi(object):
                             'name': queue['name'],
                             'stuck': False,
                             'messages': queue.get('messages'),
-                            'rate':
-                                queue['message_stats']['ack_details']['rate']
                         }
+
+                        # Use the rate from message_stats if it is there
+                        if("message_stats" in queue):
+                            details['rate'] = \
+                                queue['message_stats']['ack_details']['rate']
+                        else:
+                            details['rate'] = queue['messages_details']['rate']
+
                         if (details['messages'] > 0 and details['rate'] == 0):
                             stuck = True
                             details['stuck'] = True

--- a/junebug/tests/test_api.py
+++ b/junebug/tests/test_api.py
@@ -1217,22 +1217,19 @@ class TestJunebugApi(JunebugTestBase):
 
             yield self.assertEqual(async_failures, [])
             yield self.assert_response(
-                resp, http.INTERNAL_SERVER_ERROR, 'queues stuck', [
+                resp, http.OK, 'queues ok', [
                     {
                         'messages': 1256,
                         'name': '%s.inbound' % (channel.id),
-                        'rate': 0,
-                        'stuck': True
+                        'stuck': False
                     }, {
                         'messages': 1256,
                         'name': '%s.outbound' % (channel.id),
-                        'rate': 0,
-                        'stuck': True
+                        'stuck': False
                     }, {
                         'messages': 1256,
                         'name': '%s.event' % (channel.id),
-                        'rate': 0,
-                        'stuck': True
+                        'stuck': False
                     }])
 
     @inlineCallbacks


### PR DESCRIPTION
I looked at the response we're getting on QA and `message_stats` isn't always there, in that case we're falling back to `messages_details.rate` which is always there.